### PR TITLE
Disable editing by annotation type

### DIFF
--- a/API.md
+++ b/API.md
@@ -1023,6 +1023,15 @@ Defines whether an annotation is selected after it is created. On iOS, this func
 config.selectAnnotationAfterCreation = true;
 ```
 
+#### disableEditingByAnnotationType
+array of [`Tools`](./lib/constants.dart) constants, defaults to none.
+
+Defines annotation types that cannot be edited after creation.
+
+```dart
+config.disableEditingByAnnotationType = [Tools.annotationCreateTextSquiggly, Tools.annotationCreateTextHighlight, Tools.annotationCreateEllipse];
+```
+
 ### Annotation Menu
 
 #### hideAnnotationMenu

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -125,6 +125,7 @@ public class PluginUtils {
     public static final String KEY_CONFIG_OVERRIDE_BEHAVIOR = "overrideBehavior";
     public static final String KEY_CONFIG_TAB_TITLE = "tabTitle";
     public static final String KEY_CONFIG_PERMANENT_PAGE_NUMBER_INDICATOR = "pageNumberIndicatorAlwaysVisible";
+    public static final String KEY_CONFIG_DISABLE_EDITING_BY_ANNOTATION_TYPE = "disableEditingByAnnotationType";
 
     public static final String KEY_X1 = "x1";
     public static final String KEY_Y1 = "y1";
@@ -815,6 +816,15 @@ public class PluginUtils {
                 } else {
                     String cacheDir = context.getCacheDir().getAbsolutePath();
                     configInfo.setOpenUrlPath(cacheDir);
+                }
+                if (!configJson.isNull(KEY_CONFIG_DISABLE_EDITING_BY_ANNOTATION_TYPE)) {
+                    JSONArray array = configJson.getJSONArray(KEY_CONFIG_DISABLE_EDITING_BY_ANNOTATION_TYPE);
+                    ArrayList<String> items = convertJSONArrayToArrayList(array);
+                    int[] annotTypes = new int[items.size()];
+                    for (int i = 0; i < items.size(); i++) {
+                        annotTypes[i] = convStringToAnnotType(items.get(i));
+                    }
+                    toolManagerBuilder.disableAnnotEditing(annotTypes);
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/ios/Classes/PTFlutterDocumentController.h
+++ b/ios/Classes/PTFlutterDocumentController.h
@@ -62,6 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSString* tabTitle;
 
+@property (nonatomic, copy, nullable) NSArray<NSString*>* uneditableAnnotTypes;
+
 - (void)initViewerSettings;
 - (void)applyViewerSettings;
 

--- a/ios/Classes/PTFlutterDocumentController.m
+++ b/ios/Classes/PTFlutterDocumentController.m
@@ -149,6 +149,25 @@ static BOOL PT_addMethod(Class cls, SEL selector, void (^block)(id))
     }
 }
 
+- (void)setUneditableAnnotTypes:(NSArray<NSString *> *)uneditableAnnotTypes
+{
+    [self setAnnotationEditingPermission:uneditableAnnotTypes toValue:NO];
+}
+
+- (void)setAnnotationEditingPermission:(NSArray *)stringsArray toValue:(BOOL)value
+{
+    PTToolManager *toolManager = self.toolManager;
+
+    for (NSObject *item in stringsArray) {
+        if ([item isKindOfClass:[NSString class]]) {
+            NSString *string = (NSString *)item;
+            PTExtendedAnnotType typeToSetPermission = [self convertAnnotationNameToAnnotType:string];
+
+            [toolManager annotationOptionsForAnnotType:typeToSetPermission].canEdit = value;
+        }
+    }
+}
+
 #pragma mark - <PTBookmarkViewControllerDelegate>
 
 - (void)bookmarkViewController:(PTBookmarkViewController *)bookmarkViewController didAddBookmark:(PTUserBookmark *)bookmark

--- a/ios/Classes/PdftronFlutterPlugin.h
+++ b/ios/Classes/PdftronFlutterPlugin.h
@@ -44,6 +44,7 @@ static NSString * const PTContinuousAnnotationEditingKey = @"continuousAnnotatio
 static NSString * const PTAnnotationPermissionCheckEnabledKey = @"annotationPermissionCheckEnabled";
 static NSString * const PTOverrideBehaviorKey = @"overrideBehavior";
 static NSString * const PTTabTitleKey = @"tabTitle";
+static NSString * const PTDisableEditingByAnnotationTypeKey = @"disableEditingByAnnotationType";
 
 // tool
 static NSString * const PTAnnotationEditToolKey = @"AnnotationEdit";

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -529,6 +529,15 @@
                         [documentController setTabTitle:tabTitle];
                     }
                 }
+                else if ([key isEqualToString:PTDisableEditingByAnnotationTypeKey])
+                {
+                    
+                    NSArray* uneditableAnnotTypes = [PdftronFlutterPlugin getConfigValue:configPairs configKey:PTDisableEditingByAnnotationTypeKey class:[NSArray class] error:&error];
+                    
+                    if (!error && uneditableAnnotTypes) {
+                        [documentController setUneditableAnnotTypes:uneditableAnnotTypes];
+                    }
+                }
                 else
                 {
                     NSLog(@"Unknown JSON key in config: %@.", key);

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -42,6 +42,7 @@ class Config {
   var _overrideBehavior;
   var _tabTitle;
   var _pageNumberIndicatorAlwaysVisible;
+  var _disableEditingByAnnotationType;
 
   Config();
 
@@ -137,6 +138,8 @@ class Config {
   set pageNumberIndicatorAlwaysVisible(bool value) =>
       _pageNumberIndicatorAlwaysVisible = value;
 
+  set disableEditingByAnnotationType(List value) => _disableEditingByAnnotationType = value;
+
   Config.fromJson(Map<String, dynamic> json)
       : _disabledElements = json['disabledElements'],
         _disabledTools = json['disabledTools'],
@@ -180,7 +183,8 @@ class Config {
             json['annotationPermissionCheckEnabled'],
         _overrideBehavior = json['overrideBehavior'],
         _tabTitle = json['tabTitle'],
-        _pageNumberIndicatorAlwaysVisible = json['pageNumberIndicatorAlwaysVisible'];
+        _pageNumberIndicatorAlwaysVisible = json['pageNumberIndicatorAlwaysVisible'],
+        _disableEditingByAnnotationType = json['disableEditingByAnnotationType'];
 
   Map<String, dynamic> toJson() => {
         'disabledElements': _disabledElements,
@@ -224,5 +228,6 @@ class Config {
         'overrideBehavior': _overrideBehavior,
         'tabTitle': _tabTitle,
         'pageNumberIndicatorAlwaysVisible': _pageNumberIndicatorAlwaysVisible,
+        'disableEditingByAnnotationType': _disableEditingByAnnotationType,
       };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.62
+version: 0.0.63
 author:
 homepage:
 


### PR DESCRIPTION
Exposed a viewer configuration option that disables editing on the annotation types passed to it