### PR TITLE
(Android) setRequestedOrientation

### DIFF
--- a/API.md
+++ b/API.md
@@ -45,6 +45,23 @@ Returns a Future.
 PdftronFlutter.initialize('your_license_key');
 ```
 
+### setRequestedOrientation
+
+Changes the orientation of this activity. Android only. 
+
+For more information on the native API and orientation constants, see the [Android API reference](https://developer.android.com/reference/android/app/Activity#setRequestedOrientation(int)).
+
+Parameters:
+
+Name | Type | Required | Description
+--- | --- | --- | ---
+requestedOrientation | int | true | An orientation constant.
+
+Returns a Future.
+
+```dart
+PdftronFlutter.setRequestedOrientation(0);
+```
 
 ## Viewer Functions
 This section is for viewer related non-static methods. They would be callable in both plugin and widget versions. For example, [`openDocument`](#openDocument) is accessible in 2 ways:

--- a/android/src/main/java/com/pdftron/pdftronflutter/FlutterDocumentActivity.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/FlutterDocumentActivity.java
@@ -145,6 +145,10 @@ public class FlutterDocumentActivity extends DocumentActivity implements ViewerC
         }
     }
 
+    public static void setOrientation(int requestedOrientation) {
+        getCurrentActivity().setRequestedOrientation(requestedOrientation);
+    }
+
     public int getInitialPageNumber() {
         return mInitialPageNumber;
     }

--- a/android/src/main/java/com/pdftron/pdftronflutter/FlutterDocumentActivity.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/FlutterDocumentActivity.java
@@ -146,7 +146,9 @@ public class FlutterDocumentActivity extends DocumentActivity implements ViewerC
     }
 
     public static void setOrientation(int requestedOrientation) {
-        getCurrentActivity().setRequestedOrientation(requestedOrientation);
+        if (getCurrentActivity() != null) {
+            getCurrentActivity().setRequestedOrientation(requestedOrientation);
+        }
     }
 
     public int getInitialPageNumber() {

--- a/android/src/main/java/com/pdftron/pdftronflutter/PdftronFlutterPlugin.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/PdftronFlutterPlugin.java
@@ -34,11 +34,13 @@ import static com.pdftron.pdftronflutter.helpers.PluginUtils.FUNCTION_GET_VERSIO
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.FUNCTION_INITIALIZE;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.FUNCTION_OPEN_DOCUMENT;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.FUNCTION_SET_LEADING_NAV_BUTTON_ICON;
+import static com.pdftron.pdftronflutter.helpers.PluginUtils.FUNCTION_SET_REQUESTED_ORIENTATION;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_CONFIG;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_DOCUMENT;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_LEADING_NAV_BUTTON_ICON;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_LICENSE_KEY;
 import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_PASSWORD;
+import static com.pdftron.pdftronflutter.helpers.PluginUtils.KEY_REQUESTED_ORIENTATION;
 
 /**
  * PdftronFlutterPlugin
@@ -278,6 +280,11 @@ public class PdftronFlutterPlugin implements MethodCallHandler {
             case FUNCTION_SET_LEADING_NAV_BUTTON_ICON: {
                 String leadingNavButtonIcon = call.argument(KEY_LEADING_NAV_BUTTON_ICON);
                 FlutterDocumentActivity.setLeadingNavButtonIcon(leadingNavButtonIcon);
+                break;
+            }
+            case FUNCTION_SET_REQUESTED_ORIENTATION: {
+                int requestedOrientation = call.argument(KEY_REQUESTED_ORIENTATION);
+                FlutterDocumentActivity.setOrientation(requestedOrientation);
                 break;
             }
             default:

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -83,6 +83,7 @@ public class PluginUtils {
     public static final String KEY_ANNOTATIONS_WITH_FLAGS = "annotationsWithFlags";
     public static final String KEY_ANNOTATION_PROPERTIES = "annotationProperties";
     public static final String KEY_LEADING_NAV_BUTTON_ICON = "leadingNavButtonIcon";
+    public static final String KEY_REQUESTED_ORIENTATION = "requestedOrientation";
 
     public static final String KEY_CONFIG_DISABLED_ELEMENTS = "disabledElements";
     public static final String KEY_CONFIG_DISABLED_TOOLS = "disabledTools";
@@ -209,6 +210,7 @@ public class PluginUtils {
     public static final String FUNCTION_DELETE_ALL_ANNOTATIONS = "deleteAllAnnotations";
     public static final String FUNCTION_GET_PAGE_ROTATION = "getPageRotation";
     public static final String FUNCTION_OPEN_ANNOTATION_LIST = "openAnnotationList";
+    public static final String FUNCTION_SET_REQUESTED_ORIENTATION = "setRequestedOrientation";
 
     public static final String BUTTON_TOOLS = "toolsButton";
     public static final String BUTTON_SEARCH = "searchButton";

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -30,6 +30,7 @@ class Functions {
   static const closeAllTabs = "closeAllTabs";
   static const deleteAllAnnotations = "deleteAllAnnotations";
   static const openAnnotationList = "openAnnotationList";
+  static const setRequestedOrientation = "setRequestedOrientation";
 }
 
 // Parameters define the parameters of the functions
@@ -53,6 +54,7 @@ class Parameters {
   static const annotationsWithFlags = "annotationsWithFlags";
   static const annotationProperties = "annotationProperties";
   static const leadingNavButtonIcon = "leadingNavButtonIcon";
+  static const requestedOrientation = "requestedOrientation";
 }
 
 // Parameters define the parameters of the events

--- a/lib/pdftron_flutter.dart
+++ b/lib/pdftron_flutter.dart
@@ -171,4 +171,10 @@ class PdftronFlutter {
   static Future<void> openAnnotationList() {
     return _channel.invokeMethod(Functions.openAnnotationList);
   }
+
+  // Android only.
+  static Future<void> setRequestedOrientation(int requestedOrientation) {
+    return _channel.invokeMethod(Functions.setRequestedOrientation,
+        <String, dynamic>{Parameters.requestedOrientation: requestedOrientation});
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.68
+version: 0.0.69
 author:
 homepage:
 


### PR DESCRIPTION
Exposed plugin method `setRequestedOrientation`, which changes the orientation of the activity. Android only. 