### PR TITLE
(Android) screen orientation constants

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,13 +49,13 @@ PdftronFlutter.initialize('your_license_key');
 
 Changes the orientation of this activity. Android only. 
 
-For more information on the native API and orientation constants, see the [Android API reference](https://developer.android.com/reference/android/app/Activity#setRequestedOrientation(int)).
+For more information on the native API, see the [Android API reference](https://developer.android.com/reference/android/app/Activity#setRequestedOrientation(int)).
 
 Parameters:
 
 Name | Type | Required | Description
 --- | --- | --- | ---
-requestedOrientation | int | true | An orientation constant.
+requestedOrientation | int | true | An [Orientations](./lib/constants.dart) constant.
 
 Returns a Future.
 

--- a/API.md
+++ b/API.md
@@ -55,7 +55,7 @@ Parameters:
 
 Name | Type | Required | Description
 --- | --- | --- | ---
-requestedOrientation | int | true | An [Orientations](./lib/constants.dart) constant.
+requestedOrientation | int | true | A [PTOrientation](./lib/constants.dart) constant.
 
 Returns a Future.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -287,3 +287,23 @@ class ToolbarIcons {
   static const redaction = "PDFTron_Redact";
   static const favorite = "PDFTron_Favorite";
 }
+
+// Orientations define the screen orientations for the viewer. Android only.
+class Orientations {
+  static const unspecified = -1;
+  static const landscape = 0;
+  static const portrait = 1;
+  static const user = 2; 
+  static const behind = 3;
+  static const sensor = 4;
+  static const nosensor = 5;
+  static const sensorLandscape = 6;
+  static const sensorPortrait = 7;
+  static const reverseLandscape = 8;
+  static const reversePortrait = 9;
+  static const fullSensor = 10;
+  static const userLandscape = 11;
+  static const userPortrait = 12;
+  static const fullUser = 13;
+  static const locked = 14;
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -293,17 +293,6 @@ class Orientations {
   static const unspecified = -1;
   static const landscape = 0;
   static const portrait = 1;
-  static const user = 2; 
-  static const behind = 3;
-  static const sensor = 4;
-  static const nosensor = 5;
-  static const sensorLandscape = 6;
-  static const sensorPortrait = 7;
   static const reverseLandscape = 8;
   static const reversePortrait = 9;
-  static const fullSensor = 10;
-  static const userLandscape = 11;
-  static const userPortrait = 12;
-  static const fullUser = 13;
-  static const locked = 14;
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -288,8 +288,8 @@ class ToolbarIcons {
   static const favorite = "PDFTron_Favorite";
 }
 
-// Orientations define the screen orientations for the viewer. Android only.
-class Orientations {
+// PTOrientation defines the screen orientations for the viewer. Android only.
+class PTOrientation {
   static const unspecified = -1;
   static const landscape = 0;
   static const portrait = 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.69
+version: 0.0.70
 author:
 homepage:
 


### PR DESCRIPTION
Added a `PTOrientation` class of constants to be used with `PdftronFlutter.setRequestedOrientation`. Android only.