### PR TITLE
[Support] (iOS) hideDefaultAnnotationToolbars for redaction and form

### DIFF
--- a/ios/Classes/PTFlutterDocumentController.h
+++ b/ios/Classes/PTFlutterDocumentController.h
@@ -65,6 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSArray<NSString*>* uneditableAnnotTypes;
 
+@property (nonatomic, assign, getter=isDocCtrlrConfigured) BOOL docCtrlrConfigured;
+
 - (void)initViewerSettings;
 - (void)applyViewerSettings;
 

--- a/ios/Classes/PTFlutterDocumentController.m
+++ b/ios/Classes/PTFlutterDocumentController.m
@@ -1069,9 +1069,9 @@ static BOOL PT_addMethod(Class cls, SEL selector, void (^block)(id))
         PTAnnotationToolbarDraw: toolGroupManager.drawItemGroup,
         PTAnnotationToolbarInsert: toolGroupManager.insertItemGroup,
         //PTAnnotationToolbarFillAndSign: [NSNull null], // not implemented
-        //PTAnnotationToolbarPrepareForm: [NSNull null], // not implemented
+        PTAnnotationToolbarPrepareForm: toolGroupManager.prepareFormItemGroup,
         PTAnnotationToolbarMeasure: toolGroupManager.measureItemGroup,
-        //PTAnnotationToolbarRedaction: [NSNull null], // not implemented
+        PTAnnotationToolbarRedaction: toolGroupManager.redactItemGroup,
         PTAnnotationToolbarPens: toolGroupManager.pensItemGroup,
         PTAnnotationToolbarFavorite: toolGroupManager.favoritesItemGroup,
     };

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -23,7 +23,6 @@
 
 @property (nonatomic, assign, getter=isWidgetView) BOOL widgetView;
 @property (nonatomic, assign, getter=isMultiTabSet) BOOL multiTabSet;
-@property (nonatomic, assign, getter=isDocCtrlrConfigured) BOOL docCtrlrConfigured;
 
 @end
 
@@ -862,10 +861,10 @@
     documentController.delegate = self;
     documentController.plugin = self;
     
-    if (self.config && self.isDocCtrlrConfigured == NO) {
+    if (self.config && documentController.isDocCtrlrConfigured == NO) {
         [[self class] configureDocumentController:documentController
                                            withConfig:self.config];
-        self.docCtrlrConfigured = YES;
+        documentController.docCtrlrConfigured = YES;
     }
 }
 
@@ -1452,11 +1451,11 @@
     
     ((PTFlutterDocumentController*)self.tabbedDocumentViewController.childViewControllers.lastObject).openResult = flutterResult;
     
-    if (!self.isDocCtrlrConfigured) {
-        PTFlutterDocumentController *documentController = (PTFlutterDocumentController *) [self getDocumentController];
+    PTFlutterDocumentController *documentController = (PTFlutterDocumentController *) [self getDocumentController];
+    if (!documentController.isDocCtrlrConfigured) {
         [[self class] configureDocumentController:documentController
                                            withConfig:self.config];
-        self.docCtrlrConfigured = YES;
+        documentController.docCtrlrConfigured = YES;
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.90
+version: 0.0.91
 homepage:
 
 environment:


### PR DESCRIPTION
This PR: 
- implements `hideDefaultAnnotationToolbars` for `DefaultToolbars.prepareForm` and `DefaultToolbars.redaction`.
- fixes issue of doc controller not getting configured when reopening 