### PR TITLE
Expose openSavedCopyInNewTab, maxTabCount

### DIFF
--- a/API.md
+++ b/API.md
@@ -443,7 +443,7 @@ Name | Type | Description
 --- | --- | ---
 pageChanged | bool | whether the setting process was successful
 
-```js
+```dart
 var pageChanged = await PdftronFlutter.gotoFirstPage();
 if (pageChanged) {
   print("Successfully went to first page");
@@ -461,7 +461,7 @@ Name | Type | Description
 --- | --- | ---
 success | bool | whether the setting process was successful
 
-```js
+```dart
 var pageChanged = await PdftronFlutter.gotoLastPage();
 if (pageChanged) {
   print("Successfully went to last page");
@@ -1068,6 +1068,24 @@ Eraser Type | Description
 config.defaultEraserType = DefaultEraserType.inkEraser;
 ```
 
+#### exportPath
+string, optional
+Sets the folder path for all save options, this defaults to the app cache path. Android only.
+Example:
+```dart
+config.exportPath = "/data/data/com.pdftron.pdftronflutterexample/cache/test/";
+```
+
+#### openUrlPath
+string, optional
+
+Sets the cache folder used to cache PDF files opened using a http/https link, this defaults to the app cache path. Android only.
+Example:
+
+```dart
+config.openUrlPath = "/data/data/com.pdftron.pdftronflutterexample/cache/test/";
+```
+
 #### isBase64String
 bool, defaults to false.
 
@@ -1367,6 +1385,27 @@ Sets the tab title if [`multiTabEnabled`](#multiTabEnabled) is true. (For Androi
 
 ```dart
 config.tabTitle = 'tab1';
+```
+
+#### openSavedCopyInNewTab
+bool, optional, default to true, Android only.
+
+Sets whether the new saved file should open after saving.
+Example:
+
+```dart
+config.multiTabEnabled = true;
+config.openSavedCopyInNewTab = false;
+```
+
+#### maxTabCount
+number, optional, defaults to unlimited
+
+Sets the limit on the maximum number of tabs that the viewer could have at a time. Open more documents after reaching this limit will overwrite the old tabs.
+
+```dart
+config.multiTabEnabled = true;
+config.maxTabCount={5}
 ```
 
 ### Signature

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -113,6 +113,8 @@ public class PluginUtils {
     public static final String KEY_CONFIG_OVERRIDE_ANNOTATION_MENU_BEHAVIOR = "overrideAnnotationMenuBehavior";
     public static final String KEY_CONFIG_EXPORT_PATH = "exportPath";
     public static final String KEY_CONFIG_OPEN_URL_PATH = "openUrlPath";
+    public static final String KEY_CONFIG_OPEN_SAVED_COPY_IN_NEW_TAB = "openSavedCopyInNewTab";
+    public static final String KEY_CONFIG_MAX_TAB_COUNT = "maxTabCount";
     public static final String KEY_CONFIG_AUTO_SAVE_ENABLED = "autoSaveEnabled";
     public static final String KEY_CONFIG_PAGE_CHANGE_ON_TAP = "pageChangeOnTap";
     public static final String KEY_CONFIG_SHOW_SAVED_SIGNATURES = "showSavedSignatures";
@@ -855,6 +857,14 @@ public class PluginUtils {
                     boolean permanentPageNumberIndicator = configJson.getBoolean(KEY_CONFIG_PERMANENT_PAGE_NUMBER_INDICATOR);
                     builder.permanentPageNumberIndicator(permanentPageNumberIndicator);
                 }
+                if (!configJson.isNull(KEY_CONFIG_OPEN_SAVED_COPY_IN_NEW_TAB)) {
+                    boolean openSavedCopyInNewTab = configJson.getBoolean(KEY_CONFIG_OPEN_SAVED_COPY_IN_NEW_TAB);
+                    builder.openSavedCopyInNewTab(openSavedCopyInNewTab);
+                }
+                if (!configJson.isNull(KEY_CONFIG_MAX_TAB_COUNT)) {
+                    int maxTabCount = configJson.getInt(KEY_CONFIG_MAX_TAB_COUNT);
+                    builder.maximumTabCount(maxTabCount);
+                } 
                 if (!configJson.isNull(KEY_CONFIG_OPEN_URL_PATH)) {
                     String openUrlPath = configJson.getString(KEY_CONFIG_OPEN_URL_PATH);
                     configInfo.setOpenUrlPath(openUrlPath);

--- a/ios/Classes/PTFlutterDocumentController.h
+++ b/ios/Classes/PTFlutterDocumentController.h
@@ -63,6 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSString* tabTitle;
 
+@property (nonatomic, assign) int maxTabCount;
+
 @property (nonatomic, copy, nullable) NSArray<NSString*>* uneditableAnnotTypes;
 
 @property (nonatomic, assign, getter=isDocCtrlrConfigured) BOOL docCtrlrConfigured;

--- a/ios/Classes/PdftronFlutterPlugin.h
+++ b/ios/Classes/PdftronFlutterPlugin.h
@@ -44,6 +44,7 @@ static NSString * const PTContinuousAnnotationEditingKey = @"continuousAnnotatio
 static NSString * const PTAnnotationPermissionCheckEnabledKey = @"annotationPermissionCheckEnabled";
 static NSString * const PTOverrideBehaviorKey = @"overrideBehavior";
 static NSString * const PTTabTitleKey = @"tabTitle";
+static NSString * const PTMaxTabCountKey = @"maxTabCount";
 static NSString * const PTDisableEditingByAnnotationTypeKey = @"disableEditingByAnnotationType";
 static NSString * const PTHideViewModeItemsKey = @"hideViewModeItems";
 static NSString * const PTDefaultEraserTypeKey = @"defaultEraserType";

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -210,6 +210,14 @@
                         tabbedDocumentViewController.tabsEnabled = [multiTabValue boolValue];
                     }
                 }
+                else if ([key isEqualToString:PTMaxTabCountKey]) {
+                    NSError* error;
+                    NSNumber* maxTabCount = [PdftronFlutterPlugin getConfigValue:configPairs configKey:PTMaxTabCountKey class:[NSNumber class] error:&error];
+                    
+                    if (!error && maxTabCount) {
+                        tabbedDocumentViewController.maximumTabCount = [maxTabCount intValue];
+                    }
+                }
             }
         }
         else
@@ -269,6 +277,9 @@
                     }
                 }
                 else if ([key isEqualToString:PTMultiTabEnabledKey]) {
+                    // Handled by tabbed config.
+                }
+                else if ([key isEqualToString:PTMaxTabCountKey]) {
                     // Handled by tabbed config.
                 }
                 else if ([key isEqualToString:PTFitModeKey]) {

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -19,6 +19,8 @@ class Config {
   var _overrideAnnotationMenuBehavior;
   var _exportPath;
   var _openUrlPath;
+  var _openSavedCopyInNewTab;
+  var _maxTabCount;
   var _autoSaveEnabled;
   var _pageChangeOnTap;
   var _showSavedSignatures;
@@ -85,6 +87,10 @@ class Config {
   set exportPath(String value) => _exportPath = value;
 
   set openUrlPath(String value) => _openUrlPath = value;
+
+  set openSavedCopyInNewTab(bool value) => _openSavedCopyInNewTab = value;
+
+  set maxTabCount(int value) => _maxTabCount = value;
 
   set autoSaveEnabled(bool value) => _autoSaveEnabled = value;
 
@@ -166,6 +172,8 @@ class Config {
             json['overrideAnnotationMenuBehavior'],
         _exportPath = json['exportPath'],
         _openUrlPath = json['openUrlPath'],
+        _openSavedCopyInNewTab = json['openSavedCopyInNewTab'],
+        _maxTabCount = json['maxTabCount'],
         _autoSaveEnabled = json['autoSaveEnabled'],
         _pageChangeOnTap = json['pageChangeOnTap'],
         _showSavedSignatures = json['showSavedSignatures'],
@@ -213,6 +221,8 @@ class Config {
         'overrideAnnotationMenuBehavior': _overrideAnnotationMenuBehavior,
         'exportPath': _exportPath,
         'openUrlPath': _openUrlPath,
+        'openSavedCopyInNewTab': _openSavedCopyInNewTab,
+        'maxTabCount': _maxTabCount,
         'autoSaveEnabled': _autoSaveEnabled,
         'pageChangeOnTap': _pageChangeOnTap,
         'showSavedSignatures': _showSavedSignatures,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.93
+version: 0.0.94
 homepage:
 
 environment:


### PR DESCRIPTION
Adds `openSavedCopyInNewTab`, `maxTabCount`. Also adds missing docs for `exportPath`, `openUrlPath`.