### PR TITLE
(Android) Disable layers list

### DIFF
--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -285,6 +285,7 @@ public class PluginUtils {
     public static final String BUTTON_UNDO = "undo";
     public static final String BUTTON_REDO = "redo";
     public static final String BUTTON_EDIT_ANNOTATION_TOOLBAR = "editAnnotationToolButton";
+    public static final String BUTTON_VIEW_LAYERS = "viewLayersButton";
 
     public static final String TOOL_BUTTON_FREE_HAND = "freeHandToolButton";
     public static final String TOOL_BUTTON_HIGHLIGHT = "highlightToolButton";
@@ -1255,6 +1256,8 @@ public class PluginUtils {
                         .showFillAndSignToolbarOption(false)
                         .showEditMenuOption(false)
                         .showReflowOption(false);
+            } else if (BUTTON_VIEW_LAYERS.equals(item)) {
+                builder = builder.showViewLayersToolbarOption(false);
             }
         }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.103
+version: 0.0.104
 homepage:
 
 environment:


### PR DESCRIPTION
The functionality was only on iOS but is now on both platforms