### PR TITLE
(Support) (Android) `showDocumentSavedToast`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1612,6 +1612,15 @@ Defines whether document is automatically saved by the viewer.
 config.autoSaveEnabled = true;
 ```
 
+#### showDocumentSavedToast
+bool, defaults to true, Android only.
+
+Defines whether a toast indicating that the document has been successfully or unsuccessfully saved will appear.
+
+```dart
+config.showDocumentSavedToast = false;
+```
+
 #### useStylusAsPen
 bool, defaults to true.
 

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -38,6 +38,7 @@ import com.pdftron.pdf.tools.ToolManager;
 import com.pdftron.pdf.tools.AnnotManager;
 import com.pdftron.pdf.utils.AnnotUtils;
 import com.pdftron.pdf.utils.BookmarkManager;
+import com.pdftron.pdf.utils.CommonToast;
 import com.pdftron.pdf.utils.PdfViewCtrlSettingsManager;
 import com.pdftron.pdf.utils.Utils;
 import com.pdftron.pdf.utils.ViewerUtils;
@@ -120,6 +121,7 @@ public class PluginUtils {
     public static final String KEY_CONFIG_OPEN_SAVED_COPY_IN_NEW_TAB = "openSavedCopyInNewTab";
     public static final String KEY_CONFIG_MAX_TAB_COUNT = "maxTabCount";
     public static final String KEY_CONFIG_AUTO_SAVE_ENABLED = "autoSaveEnabled";
+    public static final String KEY_CONFIG_SHOW_DOCUMENT_SAVED_TOAST = "showDocumentSavedToast";
     public static final String KEY_CONFIG_PAGE_CHANGE_ON_TAP = "pageChangeOnTap";
     public static final String KEY_CONFIG_SHOW_SAVED_SIGNATURES = "showSavedSignatures";
     public static final String KEY_CONFIG_USE_STYLUS_AS_PEN = "useStylusAsPen";
@@ -825,6 +827,18 @@ public class PluginUtils {
                 if (!configJson.isNull(KEY_CONFIG_AUTO_SAVE_ENABLED)) {
                     boolean autoSaveEnabled = configJson.getBoolean(KEY_CONFIG_AUTO_SAVE_ENABLED);
                     configInfo.setAutoSaveEnabled(autoSaveEnabled);
+                }
+                if (!configJson.isNull(KEY_CONFIG_SHOW_DOCUMENT_SAVED_TOAST)) {
+                    boolean showDocumentSavedToast = configJson.getBoolean(KEY_CONFIG_SHOW_DOCUMENT_SAVED_TOAST);
+                    if (!showDocumentSavedToast) {
+                        CommonToast.CommonToastHandler.getInstance().setCommonToastListener(new CommonToast.CommonToastListener() {
+                            @Override
+                            public boolean canShowToast(int stringRes, @Nullable CharSequence text) {
+                                return stringRes != R.string.document_saved_toast_message &&
+                                        stringRes != R.string.document_save_error_toast_message;
+                            }
+                        });
+                    }
                 }
                 if (!configJson.isNull(KEY_CONFIG_PAGE_CHANGE_ON_TAP)) {
                     boolean pageChangeOnTap = configJson.getBoolean(KEY_CONFIG_PAGE_CHANGE_ON_TAP);

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -24,13 +24,13 @@ class Config {
   var _openSavedCopyInNewTab;
   var _maxTabCount;
   var _autoSaveEnabled;
+  var _showDocumentSavedToast;
   var _pageChangeOnTap;
   var _showSavedSignatures;
   var _useStylusAsPen;
   var _signSignatureFieldWithStamps;
   var _selectAnnotationAfterCreation;
   var _pageIndicatorEnabled;
-  var _pageStackEnabled;
   var _showQuickNavigationButton;
   var _followSystemDarkMode;
   var _downloadDialogEnabled;
@@ -115,6 +115,8 @@ class Config {
   set maxTabCount(int value) => _maxTabCount = value;
 
   set autoSaveEnabled(bool value) => _autoSaveEnabled = value;
+
+  set showDocumentSavedToast(bool value) => _showDocumentSavedToast = value;
 
   set pageChangeOnTap(bool value) => _pageChangeOnTap = value;
 
@@ -230,6 +232,7 @@ class Config {
         _openSavedCopyInNewTab = json['openSavedCopyInNewTab'],
         _maxTabCount = json['maxTabCount'],
         _autoSaveEnabled = json['autoSaveEnabled'],
+        _showDocumentSavedToast = json['showDocumentSavedToast'],
         _pageChangeOnTap = json['pageChangeOnTap'],
         _showSavedSignatures = json['showSavedSignatures'],
         _useStylusAsPen = json['useStylusAsPen'],
@@ -296,6 +299,7 @@ class Config {
         'openSavedCopyInNewTab': _openSavedCopyInNewTab,
         'maxTabCount': _maxTabCount,
         'autoSaveEnabled': _autoSaveEnabled,
+        'showDocumentSavedToast': _showDocumentSavedToast,
         'pageChangeOnTap': _pageChangeOnTap,
         'showSavedSignatures': _showSavedSignatures,
         'useStylusAsPen': _useStylusAsPen,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.104
+version: 0.0.105
 homepage:
 
 environment:


### PR DESCRIPTION
Exposed an API that controls whether a toast indicating that a document was successfully or unsuccessfully saved appears.