### PR TITLE
(Android) add singleLineToolbar

### DIFF
--- a/API.md
+++ b/API.md
@@ -1297,6 +1297,17 @@ Below is the list of supported buttons for each platform:
 config.bottomToolbar = [Buttons.reflowModeButton, Buttons.thumbnailsButton];
 ```
 
+#### singleLineToolbar
+bool, default to false.
+
+Sets whether to use 2-line toolbar or 1-line toolbar.
+
+```dart
+config.singleLineToolbar = true;
+```
+
+
+
 ### Layout
 
 #### fitMode

--- a/API.md
+++ b/API.md
@@ -1298,7 +1298,7 @@ config.bottomToolbar = [Buttons.reflowModeButton, Buttons.thumbnailsButton];
 ```
 
 #### singleLineToolbar
-bool, default to false.
+bool, default to false. Android only.
 
 Sets whether to use 2-line toolbar or 1-line toolbar.
 

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -132,6 +132,7 @@ public class PluginUtils {
     public static final String KEY_CONFIG_SHOW_QUICK_NAVIGATION_BUTTON = "showQuickNavigationButton";
     public static final String KEY_CONFIG_FOLLOW_SYSTEM_DARK_MODE = "followSystemDarkMode";
     public static final String KEY_CONFIG_DOWNLOAD_DIALOG_ENABLED = "downloadDialogEnabled";
+    public static final String KEY_CONFIG_SINGLE_LINE_TOOLBAR = "singleLineToolbar";
     public static final String KEY_CONFIG_ANNOTATION_TOOLBARS = "annotationToolbars";
     public static final String KEY_CONFIG_HIDE_DEFAULT_ANNOTATION_TOOLBARS = "hideDefaultAnnotationToolbars";
     public static final String KEY_CONFIG_HIDE_ANNOTATION_TOOLBAR_SWITCHER = "hideAnnotationToolbarSwitcher";
@@ -880,6 +881,10 @@ public class PluginUtils {
                 if (!configJson.isNull(KEY_CONFIG_DOWNLOAD_DIALOG_ENABLED)) {
                     boolean downloadDialogEnabled = configJson.getBoolean(KEY_CONFIG_DOWNLOAD_DIALOG_ENABLED);
                     builder.showDownloadDialog(downloadDialogEnabled);
+                }
+                if (!configJson.isNull(KEY_CONFIG_SINGLE_LINE_TOOLBAR)) {
+                    boolean singleLineToolbar = configJson.getBoolean(KEY_CONFIG_SINGLE_LINE_TOOLBAR);
+                    builder.useCompactViewer(singleLineToolbar);
                 }
                 if (!configJson.isNull(KEY_CONFIG_ANNOTATION_TOOLBARS)) {
                     JSONArray array = configJson.getJSONArray(KEY_CONFIG_ANNOTATION_TOOLBARS);

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -35,6 +35,7 @@ class Config {
   var _showQuickNavigationButton;
   var _followSystemDarkMode;
   var _downloadDialogEnabled;
+  var _singleLineToolbar;
   var _annotationToolbars;
   var _hideDefaultAnnotationToolbars;
   var _hideAnnotationToolbarSwitcher;
@@ -141,6 +142,8 @@ class Config {
 
   set downloadDialogEnabled(bool value) => _downloadDialogEnabled = value;
 
+  set singleLineToolbar(bool value) => _singleLineToolbar = value;
+
   set annotationToolbars(List value) => _annotationToolbars = value;
 
   set hideDefaultAnnotationToolbars(List value) =>
@@ -246,6 +249,7 @@ class Config {
         _showQuickNavigationButton = json['showQuickNavigationButton'],
         _followSystemDarkMode = json['followSystemDarkMode'],
         _downloadDialogEnabled = json['downloadDialogEnabled'],
+        _singleLineToolbar = json['_singleLineToolbar'],
         _annotationToolbars = json['annotationToolbars'],
         _hideDefaultAnnotationToolbars = json['hideDefaultAnnotationToolbars'],
         _hideAnnotationToolbarSwitcher = json['hideAnnotationToolbarSwitcher'],
@@ -314,6 +318,7 @@ class Config {
         'showQuickNavigationButton': _showQuickNavigationButton,
         'followSystemDarkMode': _followSystemDarkMode,
         'downloadDialogEnabled': _downloadDialogEnabled,
+        'singleLineToolbar': _singleLineToolbar,
         'annotationToolbars': _annotationToolbars,
         'hideDefaultAnnotationToolbars': _hideDefaultAnnotationToolbars,
         'hideAnnotationToolbarSwitcher': _hideAnnotationToolbarSwitcher,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.107
+version: 0.0.108
 homepage:
 
 environment:


### PR DESCRIPTION
Expose `singleLineToolbar` for compact viewing in Android.