### PR TITLE
[Android] Fix readOnly longPressMenu bug

### DIFF
--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -946,6 +946,9 @@ public class PluginUtils {
                 if (!configJson.isNull(KEY_CONFIG_READ_ONLY)) {
                     boolean readOnly = configJson.getBoolean(KEY_CONFIG_READ_ONLY);
                     builder.documentEditingEnabled(!readOnly);
+                    if (readOnly) {
+                        builder.skipReadOnlyCheck(false);
+                    }
                 }
                 if (!configJson.isNull(KEY_CONFIG_THUMBNAIL_VIEW_EDITING_ENABLED)) {
                     boolean thumbnailViewEditingEnabled = configJson.getBoolean(KEY_CONFIG_THUMBNAIL_VIEW_EDITING_ENABLED);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.108
+version: 0.0.109
 homepage:
 
 environment:


### PR DESCRIPTION
fixes #171 

(Android bug where long press menu was enabled when `readOnly` is true).