### PR TITLE
(Support) (Android) annotationsListFilterEnabled

### DIFF
--- a/API.md
+++ b/API.md
@@ -1502,12 +1502,21 @@ config.disableEditingByAnnotationType = [Tools.annotationCreateTextSquiggly, Too
 ```
 
 #### annotationsListEditingEnabled
-bool, optional, default value is true
+bool, optional, default value is true.
 
 If document editing is enabled, then this value determines if the annotation list is editable. 
 
 ```dart
 config.annotationsListEditingEnabled = false;
+```
+
+#### annotationsListFilterEnabled
+bool, optional, default value is true, Android only.
+
+Defines whether filtering the annotation list is possible.
+
+```dart
+config.annotationsListFilterEnabled = true;
 ```
 
 #### excludedAnnotationListTypes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ android {
 
 dependencies {
     // PDFTron SDK dependencies
-    implementation "com.pdftron:pdftron:9.1.3-beta01"
-    implementation "com.pdftron:tools:9.1.3-beta01"
+    implementation "com.pdftron:pdftron:9.1.3-beta02"
+    implementation "com.pdftron:tools:9.1.3-beta02"
 }

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -160,6 +160,7 @@ public class PluginUtils {
     public static final String KEY_CONFIG_TAB_TITLE = "tabTitle";
     public static final String KEY_CONFIG_PERMANENT_PAGE_NUMBER_INDICATOR = "pageNumberIndicatorAlwaysVisible";
     public static final String KEY_CONFIG_DISABLE_EDITING_BY_ANNOTATION_TYPE = "disableEditingByAnnotationType";
+    public static final String KEY_CONFIG_ANNOTATIONS_LIST_FILTER_ENABLED = "annotationsListFilterEnabled";
     public static final String KEY_CONFIG_HIDE_VIEW_MODE_ITEMS = "hideViewModeItems";
     public static final String KEY_CONFIG_DEFAULT_ERASER_TYPE = "defaultEraserType";
     public static final String KEY_CONFIG_AUTO_RESIZE_FREE_TEXT_ENABLED = "autoResizeFreeTextEnabled";
@@ -1051,6 +1052,10 @@ public class PluginUtils {
                         annotTypes[i] = convStringToAnnotType(items.get(i));
                     }
                     toolManagerBuilder.disableAnnotEditing(annotTypes);
+                }
+                if (!configJson.isNull(KEY_CONFIG_ANNOTATIONS_LIST_FILTER_ENABLED)) {
+                    boolean annotationsListFilterEnabled = configJson.getBoolean(KEY_CONFIG_ANNOTATIONS_LIST_FILTER_ENABLED);
+                    builder.annotationsListFilterEnabled(annotationsListFilterEnabled);
                 }
                 if (!configJson.isNull(KEY_CONFIG_HIDE_VIEW_MODE_ITEMS)) {
                    JSONArray array = configJson.getJSONArray(KEY_CONFIG_HIDE_VIEW_MODE_ITEMS);

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -62,6 +62,7 @@ class Config {
   var _tabTitle;
   var _pageNumberIndicatorAlwaysVisible;
   var _disableEditingByAnnotationType;
+  var _annotationsListFilterEnabled;
   var _hideViewModeItems;
   var _defaultEraserType;
   var _autoResizeFreeTextEnabled;
@@ -213,6 +214,8 @@ class Config {
 
   set disableEditingByAnnotationType(List value) => _disableEditingByAnnotationType = value;
 
+  set annotationsListFilterEnabled(bool value) => _annotationsListFilterEnabled = value;
+
   set hideViewModeItems(List value) => _hideViewModeItems = value;
 
   set defaultEraserType(String value) => _defaultEraserType = value;
@@ -298,6 +301,7 @@ class Config {
         _tabTitle = json['tabTitle'],
         _pageNumberIndicatorAlwaysVisible = json['pageNumberIndicatorAlwaysVisible'],
         _disableEditingByAnnotationType = json['disableEditingByAnnotationType'],
+        _annotationsListFilterEnabled = json['annotationsListFilterEnabled'],
         _hideViewModeItems = json['hideViewModeItems'],
         _defaultEraserType = json['defaultEraserType'],
         _autoResizeFreeTextEnabled = json['autoResizeFreeTextEnabled'],
@@ -373,6 +377,7 @@ class Config {
         'tabTitle': _tabTitle,
         'pageNumberIndicatorAlwaysVisible': _pageNumberIndicatorAlwaysVisible,
         'disableEditingByAnnotationType': _disableEditingByAnnotationType,
+        'annotationsListFilterEnabled': _annotationsListFilterEnabled,
         'hideViewModeItems': _hideViewModeItems,
         'defaultEraserType' : _defaultEraserType,
         'autoResizeFreeTextEnabled': _autoResizeFreeTextEnabled,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.114
+version: 0.0.115
 homepage:
 
 environment:


### PR DESCRIPTION
Exposed API to set whether the annotations list can be filtered.