### PR TITLE
[Support-27188] Add option to hide showFileAttachments option

### DIFF
--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -322,6 +322,7 @@ public class PluginUtils {
     public static final String BUTTON_REDO = "redo";
     public static final String BUTTON_EDIT_ANNOTATION_TOOLBAR = "editAnnotationToolButton";
     public static final String BUTTON_VIEW_LAYERS = "viewLayersButton";
+    public static final String BUTTON_SHOW_FILE_ATTACHMENT = "showFileAttachmentButton";
 
     public static final String TOOL_BUTTON_FREE_HAND = "freeHandToolButton";
     public static final String TOOL_BUTTON_HIGHLIGHT = "highlightToolButton";
@@ -1380,6 +1381,8 @@ public class PluginUtils {
                         .showReflowOption(false);
             } else if (BUTTON_VIEW_LAYERS.equals(item)) {
                 builder = builder.showViewLayersToolbarOption(false);
+            } else if (BUTTON_SHOW_FILE_ATTACHMENT.equals(item)) {
+                builder = builder.showFileAttachmentOption(false);
             }
         }
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -148,6 +148,7 @@ class Buttons {
   static const eraserButton = 'eraserButton';
   static const undo = 'undo';
   static const redo = 'redo';
+  static const showFileAttachmentButton = 'showFileAttachmentButton';
 
   // Android only
   static const editAnnotationToolbarButton = 'editAnnotationToolButton';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A new flutter plugin project.
-version: 0.0.117
+version: 0.0.118
 homepage:
 
 environment:


### PR DESCRIPTION
Add option to disable showFileAttachments option in overflow menu

Test with:

`config.disabledElements = [Buttons.showFileAttachmentButton];`

Sample PDF with File Attachments:
https://github.com/XodoDocs/Xodo/files/3592919/INDEX.zip