### PR TITLE
iOS layoutMode fix

### DIFF
--- a/ios/Classes/PTFlutterDocumentController.m
+++ b/ios/Classes/PTFlutterDocumentController.m
@@ -123,6 +123,12 @@ static BOOL PT_addMethod(Class cls, SEL selector, void (^block)(id))
     [self applyLayoutMode];
 }
 
+- (void)didOpenDocument
+{
+    [super didOpenDocument];
+    [self applyLayoutMode];
+}
+
 - (BOOL)isTopToolbarEnabled
 {
     return (!self.topAppNavBarHidden && !self.topToolbarsHidden);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.22
+version: 1.0.0-beta.23
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
`PTFlutterDocumentController` now implements the `didOpenDocument` method from `PTDocumentBaseViewController` and calls `applyLayoutMode` from there.

The previous setting was getting clobbered internally.