### PR TITLE
Add support for hiding save reduced copy button on iOS (CPM-30)

### DIFF
--- a/ios/Classes/PdftronFlutterPlugin.h
+++ b/ios/Classes/PdftronFlutterPlugin.h
@@ -149,6 +149,7 @@ static NSString * const PTSaveCopyButtonKey = @"saveCopyButton";
 static NSString * const PTSaveIdenticalCopyButtonKey = @"saveIdenticalCopyButton";
 static NSString * const PTSaveFlattenedCopyButtonKey = @"saveFlattenedCopyButton";
 static NSString * const PTSaveCroppedCopyButtonKey = @"saveCroppedCopyButton";
+static NSString * const PTSaveReducedCopyButtonKey = @"saveReducedCopyButton";
 static NSString * const PTEditPagesButtonKey = @"editPagesButton";
 static NSString * const PTPrintButtonKey = @"printButton";
 static NSString * const PTCloseButtonKey = @"closeButton";

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -1119,7 +1119,15 @@
                     [exportItems removeObject:documentController.exportCroppedCopyButtonItem];
                     documentController.exportItems = [exportItems copy];
                 }
-            },    
+            },
+        PTSaveReducedCopyButtonKey:
+            ^{
+                if (![documentController isExportButtonHidden]) {
+                    NSMutableArray * exportItems = [documentController.exportItems mutableCopy];
+                    [exportItems removeObject:documentController.exportReducedFileSizeCopyButtonItem];
+                    documentController.exportItems = [exportItems copy];
+                }
+            },
     };
     
     for(NSObject* item in elementsToDisable)

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -71,7 +71,7 @@ class Functions {
   static const zoomToRect = "zoomToRect";
   static const getZoom = "getZoom";
   static const setZoomLimits = "setZoomLimits";
-  static const smartZoom = "smartZoom"; 
+  static const smartZoom = "smartZoom";
   static const getVisiblePages = "getVisiblePages";
 }
 
@@ -150,6 +150,8 @@ class Buttons {
   static const saveCopyButton = 'saveCopyButton';
   static const saveIdenticalCopyButton = 'saveIdenticalCopyButton';
   static const saveFlattenedCopyButton = 'saveFlattenedCopyButton';
+  static const saveReducedCopyButton = 'saveReducedCopyButton';
+  static const saveCroppedCopyButton = 'saveCroppedCopyButton';
   static const editPagesButton = 'editPagesButton';
   static const printButton = 'printButton';
   static const closeButton = 'closeButton';
@@ -172,8 +174,6 @@ class Buttons {
 
   /// Android only.
   static const editAnnotationToolbarButton = 'editAnnotationToolButton';
-  static const saveReducedCopyButton = 'saveReducedCopyButton';
-  static const saveCroppedCopyButton = 'saveCroppedCopyButton';
 }
 
 /// Defines the various kinds of tools for the viewer.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.33
+version: 1.0.0-beta.34
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues
@@ -37,7 +37,6 @@ flutter:
 #
 # An image asset can refer to one or more resolution-specific "variants", see
 # https://flutter.io/assets-and-images/#resolution-aware.
-
 # To add custom fonts to your plugin package, add a fonts section here,
 # in this "flutter" section. Each entry in this list should have a
 # "family" key with the font family name, and a "fonts" key with a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.34
+version: 1.0.0-beta.35
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
https://linear.app/pdftron/issue/CPM-30/[support-32401]-support-the-buttonssavereducedcopybutton-on-ios