### PR TITLE
Fix Hygen generator destination paths

### DIFF
--- a/_templates/config-generator/new/config.ejs.t
+++ b/_templates/config-generator/new/config.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/config.dart
+to: lib/src/config.dart
 after: // Hygen Generated Configs \(1\)
 inject: true
 ---

--- a/_templates/config-generator/new/config2.ejs.t
+++ b/_templates/config-generator/new/config2.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/config.dart
+to: lib/src/config.dart
 after: // Hygen Generated Configs \(2\)
 inject: true
 ---

--- a/_templates/config-generator/new/config3.ejs.t
+++ b/_templates/config-generator/new/config3.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/config.dart
+to: lib/src/config.dart
 after: // Hygen Generated Configs \(3\)
 inject: true
 ---

--- a/_templates/config-generator/new/config4.ejs.t
+++ b/_templates/config-generator/new/config4.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/config.dart
+to: lib/src/config.dart
 after: // Hygen Generated Configs \(4\)
 inject: true
 ---

--- a/_templates/listener-generator/new/constants.ejs.t
+++ b/_templates/listener-generator/new/constants.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/constants.dart
+to: lib/src/constants.dart
 after: Hygen Generated Event Listeners
 inject: true
 ---

--- a/_templates/listener-generator/new/events.ejs.t
+++ b/_templates/listener-generator/new/events.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/events.dart
+to: lib/src/events.dart
 after: Hygen Generated Event Listeners \(1\)
 inject: true
 ---

--- a/_templates/listener-generator/new/events2.ejs.t
+++ b/_templates/listener-generator/new/events2.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/events.dart
+to: lib/src/events.dart
 after: Hygen Generated Event Listeners \(2\)
 inject: true
 ---
@@ -12,4 +12,4 @@ inject: true
      args = args.substring(0, args.length - 2)
    }
 -%>
-typedef void <%= h.changeCase.pascalCase(name) %>Listener(<%= args %>);<% -%>
+typedef void <%= h.changeCase.pascalCase(name) %>Listener(<%- args %>);<% -%>

--- a/_templates/listener-generator/new/events3.ejs.t
+++ b/_templates/listener-generator/new/events3.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/events.dart
+to: lib/src/events.dart
 after: Hygen Generated Event Listeners \(3\)
 inject: true
 ---

--- a/_templates/listener-generator/new/events4.ejs.t
+++ b/_templates/listener-generator/new/events4.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/events.dart
+to: lib/src/events.dart
 after: Hygen Generated Event Listeners \(4\)
 inject: true
 ---

--- a/_templates/method-generator/new/constants.ejs.t
+++ b/_templates/method-generator/new/constants.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/constants.dart
+to: lib/src/constants.dart
 after: Hygen Generated Methods
 inject: true
 ---

--- a/_templates/method-generator/new/constants2.ejs.t
+++ b/_templates/method-generator/new/constants2.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/constants.dart
+to: lib/src/constants.dart
 after: Hygen Generated Method Parameters
 inject: true
 ---

--- a/_templates/method-generator/new/document_view.ejs.t
+++ b/_templates/method-generator/new/document_view.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: lib/document_view.dart
+to: lib/src/document_view.dart
 after: Hygen Generated Methods
 inject: true
 ---
@@ -16,6 +16,6 @@ inject: true
      args = args.substring(0, args.length - 1) + '\n    '
    }
 -%>
-  Future<<%= returnType %>> <%= name %>(<%- params %>) {
+  Future<<%- returnType %>> <%= name %>(<%- params %>) {
     return _channel.invokeMethod(Functions.<%= name %><%- args %>);
   }

--- a/_templates/method-generator/new/pdftron_flutter.ejs.t
+++ b/_templates/method-generator/new/pdftron_flutter.ejs.t
@@ -16,6 +16,6 @@ inject: true
      args = args.substring(0, args.length - 1) + '\n    '
    }
 -%>
-  static Future<<%= returnType %>> <%= name %>(<%- params %>) {
+  static Future<<%- returnType %>> <%= name %>(<%- params %>) {
     return _channel.invokeMethod(Functions.<%= name %><%- args %>);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.37
+version: 1.0.0-beta.38
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
Some of the Hygen generator templates were broken due to https://github.com/PDFTron/pdftron-flutter/pull/198 moving some dart files into a new directory. Destination paths has been changed to reflect this.

Some input tags were also changed to fix incorrectly HTML escaping symbols.