### PR TITLE
[Support-33363 | iOS] Implement disabledTools for annotationCreateLinkText

### DIFF
--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -2938,7 +2938,7 @@
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionToolKey]) {
         toolClass = [PTRectangleRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkToolKey]) {
-        // TODO
+        toolClass = [PTAnnotationCreateLinkToolKey class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionTextToolKey]) {
         toolClass = [PTTextRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkTextToolKey]) {

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -2938,7 +2938,7 @@
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionToolKey]) {
         toolClass = [PTRectangleRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkToolKey]) {
-        toolClass = [PTAnnotationCreateLinkToolKey class];
+        toolClass = [PTLinkCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionTextToolKey]) {
         toolClass = [PTTextRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkTextToolKey]) {

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -979,7 +979,7 @@
                 // TODO
             }
             else if ([string isEqualToString:PTAnnotationCreateLinkTextToolKey]) {
-                // TODO
+                toolManager.linkAnnotationOptions.canCreate = value;
             }
             else if ([string isEqualToString:PTFormCreateTextFieldToolKey]) {
                 // TODO
@@ -2942,7 +2942,7 @@
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionTextToolKey]) {
         toolClass = [PTTextRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkTextToolKey]) {
-        // TODO
+        toolClass = [PTLinkCreate class];
     } else if ([toolMode isEqualToString:PTFormCreateTextFieldToolKey]) {
         // TODO
     } else if ([toolMode isEqualToString:PTFormCreateCheckboxFieldToolKey]) {

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -2938,11 +2938,11 @@
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionToolKey]) {
         toolClass = [PTRectangleRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkToolKey]) {
-        toolClass = [PTLinkCreate class];
+        // TODO
     } else if ([toolMode isEqualToString:PTAnnotationCreateRedactionTextToolKey]) {
         toolClass = [PTTextRedactionCreate class];
     } else if ([toolMode isEqualToString:PTAnnotationCreateLinkTextToolKey]) {
-        toolClass = [PTLinkCreate class];
+        // TODO
     } else if ([toolMode isEqualToString:PTFormCreateTextFieldToolKey]) {
         // TODO
     } else if ([toolMode isEqualToString:PTFormCreateCheckboxFieldToolKey]) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.44
+version: 1.0.0-beta.43
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.43
+version: 1.0.0-beta.44
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
support tick ref:
https://support.pdftron.com/a/tickets/33363

closes NSDK-181

added functionality to disabledTools for:
PTAnnotationCreateLinkTextToolKey

based on android implementation, accesses the same annotation type:
```
if (TOOL_ANNOTATION_CREATE_LINK.equals(item) || TOOL_ANNOTATION_CREATE_LINK_TEXT.equals(item)) {
            annotType = Annot.e_Link;
```