### PR TITLE
Switch to the split PDFTron & PDFTronTools pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ The following instructions are only applicable to Android development; click her
 
 The following instructions are only applicable to iOS development; click here for the [Android counterpart](#android).
 
+> **Note**
+> (August 2022) There are new podspec files to use when integrating the PDFTron Flutter Wrapper for iOS:
+> - `PDFTron` CocoaPod, providing `PDFNet.xcframework`: https://pdftron.com/downloads/ios/flutter/pdftron/latest.podspec
+> - `PDFTronTools` CocoaPod, providing `Tools.xcframework`: https://pdftron.com/downloads/ios/flutter/pdftron-tools/latest.podspec
+> Please update your `ios/Podfile` accordingly.
+
 4. Open `myapp/ios/Podfile` file and add:
 	```diff
 	  # Uncomment this line to define a global platform for your project
@@ -152,7 +158,8 @@ The following instructions are only applicable to iOS development; click here fo
 	  target 'Runner' do
 	    ...
 	+   # PDFTron Pods
-	+   pod 'PDFNet', podspec: 'https://www.pdftron.com/downloads/ios/cocoapods/xcframeworks/pdfnet/latest.podspec'
+	+   pod 'PDFTron', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron/latest.podspec'
+	+   pod 'PDFTronTools', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron-tools/latest.podspec'
 	  end
 	```
 5. To ensure integration process is successful, run `flutter build ios --no-codesign` 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ The following instructions are only applicable to Android development; click her
 The following instructions are only applicable to iOS development; click here for the [Android counterpart](#android).
 
 > **Note**
-> (August 2022) There are new podspec files to use when integrating the PDFTron Flutter Wrapper for iOS:
+> (August 2022) 
+>
+> There are new podspec files to use when integrating the PDFTron Flutter Wrapper for iOS:
 > - `PDFTron` CocoaPod, providing `PDFNet.xcframework`: https://pdftron.com/downloads/ios/flutter/pdftron/latest.podspec
 > - `PDFTronTools` CocoaPod, providing `Tools.xcframework`: https://pdftron.com/downloads/ios/flutter/pdftron-tools/latest.podspec
+>
 > Please update your `ios/Podfile` accordingly.
 
 4. Open `myapp/ios/Podfile` file and add:

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,8 @@ target 'Runner' do
 
   # PDFTron Pods
   use_frameworks!
-  pod 'PDFNet', podspec: 'https://www.pdftron.com/downloads/ios/cocoapods/xcframeworks/pdfnet/latest.podspec'
+  pod 'PDFTron', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron/latest.podspec'
+  pod 'PDFTronTools', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron-tools/latest.podspec'
 end
 
 post_install do |installer|

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -168,7 +168,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -246,14 +246,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/pdftron_flutter/pdftron_flutter.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flutter/Flutter.framework/Flutter",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PDFNet/PDFNet.framework/PDFNet",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Tools/Tools.framework/Tools",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PDFTron/PDFNet.framework/PDFNet",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PDFTronTools/Tools.framework/Tools",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pdftron_flutter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PDFNet.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tools.framework",
 			);
@@ -291,7 +289,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
-				"${PODS_ROOT}/PDFNet/Tools-Localization",
+				"${PODS_ROOT}/PDFTronTools/Tools-Localization",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -397,7 +395,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -520,7 +521,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -543,7 +547,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/pdftron_flutter.podspec
+++ b/ios/pdftron_flutter.podspec
@@ -15,7 +15,10 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PDFNet'
+  s.dependency 'PDFTron'
+  s.dependency 'PDFTronTools'
+
+  s.frameworks = 'PDFNet', 'Tools'
 
   s.ios.deployment_target = '8.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.0-beta.45
+version: 1.0.0-beta.46
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
There are recurring issues with the `PDFNet` XCFrameworks CocoaPod where only one of the `PDFNet.framework` or `Tools.framework` bundles are copied into the app bundle.

**This is a breaking change for existing users of the pdftron-flutter wrapper.**
The required change is to replace usage of the `PDFNet` pod in the `ios/Podfile` file with:
```ruby
  pod 'PDFTron', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron/latest.podspec'
  pod 'PDFTronTools', podspec: 'https://pdftron.com/downloads/ios/flutter/pdftron-tools/latest.podspec'
```
and run the `pod install` command from within the `ios/` directory.