### PR TITLE
AnnotationSmartPen support in flutter-iOS

### DIFF
--- a/ios/Classes/PdftronFlutterPlugin.h
+++ b/ios/Classes/PdftronFlutterPlugin.h
@@ -119,6 +119,7 @@ static NSString * const PTFormCreateRadioFieldToolKey = @"FormCreateRadioField";
 static NSString * const PTFormCreateComboBoxFieldToolKey = @"FormCreateComboBoxField";
 static NSString * const PTFormCreateListBoxFieldToolKey = @"FormCreateListBoxField";
 static NSString * const PTPencilKitDrawingToolKey = @"PencilKitDrawing";
+static NSString * const PTAnnotationSmartPenToolKey = @"AnnotationSmartPen";
 
 // button
 static NSString * const PTStickyToolButtonKey = @"stickyToolButton";

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -1022,6 +1022,9 @@
             else if ([string isEqualToString:PTPencilKitDrawingToolKey]) {
                 toolManager.pencilDrawingAnnotationOptions.canCreate = value;
             }
+            else if ([string isEqualToString:PTAnnotationSmartPenToolKey]) {
+                toolManager.smartPenEnabled = value;
+            }
         }
     }
 }
@@ -3018,6 +3021,8 @@
         // TODO
     } else if ([toolMode isEqualToString:PTPencilKitDrawingToolKey]) {
         toolClass = [PTPencilDrawingCreate class];
+    } else if ([toolMode isEqualToString:PTAnnotationSmartPenToolKey]) {
+        toolClass = [PTSmartPen class];
     }
 
     if (toolClass) {

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -241,12 +241,10 @@ class Tools {
   static const formCreateRadioField = 'FormCreateRadioField';
   static const formCreateComboBoxField = 'FormCreateComboBoxField';
   static const formCreateListBoxField = 'FormCreateListBoxField';
+  static const annotationSmartPen = 'AnnotationSmartPen';
 
   /// iOS only.
   static const pencilKitDrawing = 'PencilKitDrawing';
-
-  /// Android only.
-  static const annotationSmartPen = 'AnnotationSmartPen';
 
   /// Android only.
   static const annotationLasso = 'AnnotationLasso';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.1-11
+version: 1.0.1-12
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
- moved constant off android only comment for 'AnnotationSmartPen'
- added ios flutter plugin support for AnnotationSmartPen to disable smart pen

closes [FLUSDK-17](https://apryse.atlassian.net/browse/FLUSDK-17)

Test Instructions

add `config.disabledTools = [Tools.annotationSmartPen];` to configs 
check app to see if smart pen is gone
![image](https://user-images.githubusercontent.com/15988850/229943059-9c6df835-366c-4c3b-bf8b-f929b9d0b759.png)


