### PR TITLE
Fix package version update script again

### DIFF
--- a/.github/workflows/versionBump.yml
+++ b/.github/workflows/versionBump.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get Latest pubspec.yaml
         run: | 
           git fetch 
-          git merge origin/master
+          git checkout origin/master pubspec.yaml
           git add pubspec.yaml
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.1-23
+version: 1.0.1-24
 homepage: https://www.pdftron.com
 repository: https://github.com/PDFTron/pdftron-flutter
 issue_tracker: https://github.com/PDFTron/pdftron-flutter/issues


### PR DESCRIPTION
- Revert merge master, instead just checkout
- Upon further investigation, it seems that the `-m` tag did nothing, so we can just take it out and keep using `checkout`